### PR TITLE
[Feature][Add Context Menu to Beat/Sample Items]

### DIFF
--- a/public/components/panel/studioPanel/itemContextPrompt.js
+++ b/public/components/panel/studioPanel/itemContextPrompt.js
@@ -52,7 +52,7 @@ const ItemContextPrompt = props => {
   const openInputValue = `${isSample ? 'Add to' : 'Open in'} Workstation`
   const [activityMessage, setActivityMessage] = useState(null)
 
-  const handleItemAudioDownload = () => {
+  const handleItemAudioDownload = _ => {
     // use audiobuffer-to-wav to download
     props.setIsMakingNetworkActivity(true)
     if (isSample) {
@@ -105,7 +105,7 @@ const ItemContextPrompt = props => {
    * Handles the delete request and informs parent component when completed.
    * A failed request will have no visible effect on the UI
    */
-  const handleItemDelete = () => {
+  const handleItemDelete = _ => {
     props.setIsMakingNetworkActivity(true)
     if (isSample) {
       RequestDeleteSample(props.userInfo, props.value, status => {
@@ -124,11 +124,11 @@ const ItemContextPrompt = props => {
     }
   }
 
-  const isInActivity = () => {
+  const isInActivity = _ => {
     return activityMessage != null && activityMessage != undefined
   }
 
-  const getActivityMessage = () => {
+  const getActivityMessage = _ => {
     if (!isInActivity()) {
       return <></>
     } else {

--- a/public/components/panel/studioPanel/itemContextPrompt.js
+++ b/public/components/panel/studioPanel/itemContextPrompt.js
@@ -1,0 +1,137 @@
+import React from 'react'
+import { ListObjectType } from '../verticalListPanel/verticalListPanel'
+import { GridBeatObject, GridSampleObject } from '../workstationPanel/gridObjects'
+import {
+  RequestDeleteBeat,
+  RequestDeleteSample,
+  VerifiedUserInfo,
+  ResultStatus,
+} from '../../requestService/itemRequestService'
+
+/// Generic info for showing prompt dialog
+const OpenContextPromptInfo = {
+  title: null,
+  shouldShowPrompt: true,
+  value: GridBeatObject,
+  type: ListObjectType,
+  onLoadItemToGrid: null,
+  onItemDeleted: null,
+  onCancel: null,
+}
+
+/// Generic info for cloase prompt dialog
+const CloseContextPromptInfo = {
+  title: null,
+  shouldShowPrompt: false,
+  value: GridBeatObject,
+  type: ListObjectType,
+  onLoadItemToGrid: null,
+  onItemDeleted: null,
+  onCancel: null,
+}
+
+/**
+ * @param {{
+ * promptTitle: String,
+ * userInfo: VerifiedUserInfo,
+ * value: GridBeatObject | GridSampleObject,
+ * type: ListObjectType,
+ * setIsMakingNetworkActivity: (Boolean) => void,
+ * onLoadItemToGrid: (value: GridBeatObject | GridSampleObject) => void,
+ * onItemDeleted: (value: GridBeatObject | GridSampleObject) => void,
+ * onCancel: () => void
+ * }} props
+ */
+const ItemContextPrompt = props => {
+  const isSample = props.type == ListObjectType.Sample
+  const deleteInputValue = `Delete ${isSample ? 'Sample' : 'Beat'}`
+  const openInputValue = `${isSample ? 'Add to' : 'Open in'} Workstation`
+
+  const handleItemAudioDownload = () => {
+    // use audiobuffer-to-wav to download
+  }
+
+  const handleItemDelete = () => {
+    props.setIsMakingNetworkActivity(true)
+    if (isSample) {
+      RequestDeleteSample(props.userInfo, props.value, status => {
+        if (status == ResultStatus.Success) {
+          props.onItemDeleted(props.value)
+        }
+        props.setIsMakingNetworkActivity(false)
+      })
+    } else {
+      RequestDeleteBeat(props.userInfo, props.value, status => {
+        if (status == ResultStatus.Success) {
+          props.onItemDeleted(props.value)
+        }
+        props.setIsMakingNetworkActivity(false)
+      })
+    }
+  }
+
+  return (
+    <div className="SaveBeatPromptBackground">
+      <div className="ItemContextPrompt">
+        <h4 className="SaveBeatPromptText">{props.promptTitle}</h4>
+        <input
+          className="LoginInput PromptButton ContextButton"
+          type="button"
+          value={openInputValue}
+          onClick={_ => props.onLoadItemToGrid(props.value)}
+        ></input>
+        <input
+          className="LoginInput PromptButton ContextButton"
+          type="button"
+          value="Download Audio File"
+          onClick={_ => handleItemAudioDownload()}
+        ></input>
+        <input
+          className="LoginInput PromptButton ContextButton"
+          type="button"
+          value={deleteInputValue}
+          onClick={_ => {
+            if (window.confirm(`Delete ${props.promptTitle} permanently?`)) {
+              handleItemDelete()
+            }
+          }}
+        ></input>
+        <input
+          className="LoginInput PromptButton ContextButton"
+          type="button"
+          value="Cancel"
+          onClick={_ => props.onCancel()}
+        ></input>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * A wrapper to abstract hiding/showing the context prompt
+ * Also handles breaking out prompt info to keys
+ * @param {{
+ * promptInfo: CloseContextPromptInfo,
+ * setIsMakingNetworkActivity: (Boolean) => void
+ * }} props
+ */
+const ItemContextPromptWrapper = props => {
+  const { promptInfo } = props
+  if (!promptInfo.shouldShowPrompt) {
+    return <></>
+  } else {
+    return (
+      <ItemContextPrompt
+        promptTitle={promptInfo.title ?? ''}
+        value={promptInfo.value}
+        type={promptInfo.type}
+        setIsMakingNetworkActivity={props.setIsMakingNetworkActivity}
+        onLoadItemToGrid={props.promptInfo.onLoadItemToGrid}
+        onItemDeleted={props.promptInfo.onItemDeleted}
+        onCancel={props.promptInfo.onCancel}
+      ></ItemContextPrompt>
+    )
+  }
+}
+
+export { OpenContextPromptInfo, CloseContextPromptInfo, ItemContextPromptWrapper }

--- a/public/components/panel/studioPanel/itemContextPrompt.js
+++ b/public/components/panel/studioPanel/itemContextPrompt.js
@@ -51,6 +51,10 @@ const ItemContextPrompt = props => {
     // use audiobuffer-to-wav to download
   }
 
+  /**
+   * Handles the delete request and informs parent component when completed.
+   * A failed request will have no visible effect on the UI
+   */
   const handleItemDelete = () => {
     props.setIsMakingNetworkActivity(true)
     if (isSample) {

--- a/public/components/panel/studioPanel/studioPanel.css
+++ b/public/components/panel/studioPanel/studioPanel.css
@@ -89,3 +89,14 @@
 .fileContainer.chooseFileButton {
   border-radius: 4px;
 }
+
+.ItemContextPrompt {
+  width: 350px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.ContextButton {
+  width: 80%;
+}

--- a/public/components/requestService/itemRequestService.js
+++ b/public/components/requestService/itemRequestService.js
@@ -1,0 +1,33 @@
+import { VerifiedUserInfo } from './authRequestService'
+import { GridBeatObject, GridSampleObject } from '../panel/workstationPanel/gridObjects'
+import { ResultStatus } from './requestService'
+
+const mockNetworkDelayMillisecond = 2000
+
+/**
+ *
+ * @param {VerifiedUserInfo} userInfo
+ * @param {GridBeatObject} beatObject
+ * @param {(status: ResultStatus) => void} didCompleteRequest
+ */
+const RequestDeleteBeat = (userInfo, beatObject, didCompleteRequest) => {
+  // placeholder for request handler
+  setTimeout(() => {
+    didCompleteRequest(ResultStatus.Success)
+  }, mockNetworkDelayMillisecond)
+}
+
+/**
+ *
+ * @param {VerifiedUserInfo} userInfo
+ * @param {GridSampleObject} sampleObject
+ * @param {(status: ResultStatus) => void} didCompleteRequest
+ */
+const RequestDeleteSample = (userInfo, sampleObject, didCompleteRequest) => {
+  // placeholder for request handler
+  setTimeout(() => {
+    didCompleteRequest(ResultStatus.Success)
+  }, mockNetworkDelayMillisecond)
+}
+
+export { RequestDeleteBeat, RequestDeleteSample, VerifiedUserInfo, ResultStatus }


### PR DESCRIPTION
### Summary
* Added a context pop-up menu that handles the options available for when a beat/sample is clicked in the studio.
* The following options are available
    * Beats: Open in Workstation, Delete Beat, Cancel
    * Sample: Add to Workstation, Download Audio File, Delete Sample, Cancel
* Added some wrapper handlers (`RequestDeleteBeat` and `RequestSampleBeat`) which will call the request modules when those are ready.